### PR TITLE
Bump version to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format of this file is based on [Keep a Changelog](https://keepachangelog.co
 
 ## [Unreleased]
 
+## [2.6.0]
+
 ### Added
 
 - Initial open-source release of `fp`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "fp"
-version = "2.5.1"
+version = "2.6.0"
 dependencies = [
  "abort-on-drop",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fp"
-version = "2.5.1"
+version = "2.6.0"
 authors = ["Team Fiberplane"]
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
# Description

Release version `2.6.0`

### Added

- Initial open-source release of `fp`.

### Fixed

- [CI] Fixed syncing of the `fp` reference to ReadMe (#213)
- Update some crates to resolve some security vulnerabilities (#212)
- Update dependencies to resolve dependabot issues (#215)

---

- [ ] Update CHANGELOG.md
