### PR TITLE
various quality of life fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format of this file is based on [Keep a Changelog](https://keepachangelog.co
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix interactive notebook picker displaying the oldest notebooks first (#220)
+
+### Added
+
+- Display description in data source table view (#220)
+- Add message informing user how to exit `fp shell` (#220)
+
 ## [2.6.0]
 
 ### Added

--- a/src/data_sources.rs
+++ b/src/data_sources.rs
@@ -341,6 +341,9 @@ pub struct DataSourceRow {
     #[table(title = "Name")]
     pub name: String,
 
+    #[table(title = "Description")]
+    pub description: String,
+
     #[table(title = "Daemon Name")]
     pub daemon_name: String,
 
@@ -358,6 +361,7 @@ impl From<DataSource> for DataSourceRow {
     fn from(data_source: DataSource) -> Self {
         Self {
             name: data_source.name.to_string(),
+            description: data_source.description.unwrap_or_default(),
             daemon_name: data_source
                 .proxy_name
                 .map_or_else(String::new, |name| name.to_string()),

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -244,6 +244,7 @@ pub async fn notebook_picker_with_prompt(
 
     let display_items: Vec<_> = results
         .iter()
+        .rev() // reverse the list to show notebooks which have been created most recently first
         .map(|notebook| format!("{} ({})", notebook.title, notebook.id))
         .collect();
 

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -234,7 +234,8 @@ pub async fn notebook_picker_with_prompt(
     pb.set_message("Fetching recent notebooks");
     pb.enable_steady_tick(100);
 
-    let results = notebook_search(client, workspace_id, NotebookSearch::default()).await?;
+    let mut results = notebook_search(client, workspace_id, NotebookSearch::default()).await?;
+    results.reverse(); // reverse the list to show notebooks which have been created most recently first
 
     pb.finish_and_clear();
 
@@ -244,7 +245,6 @@ pub async fn notebook_picker_with_prompt(
 
     let display_items: Vec<_> = results
         .iter()
-        .rev() // reverse the list to show notebooks which have been created most recently first
         .map(|notebook| format!("{} ({})", notebook.title, notebook.id))
         .collect();
 

--- a/src/shell/shell_launcher.rs
+++ b/src/shell/shell_launcher.rs
@@ -121,6 +121,8 @@ impl ShellLauncher {
                     .await?;
             }
         }
+
+        tokio::io::stdout().write_all(b"Recording started! In order to finish recording and exit, press CTRL + D or type `exit`.\n").await?;
         Ok(())
     }
 }


### PR DESCRIPTION
# Description

- display the newest notebooks first in notebook picker (fixes FP-2970)
- display description in data sources table view (fixes FP-2717)
- add message how to exit fp shell (fixes FP-2823). screenshot:
![image](https://user-images.githubusercontent.com/24739711/219081029-cc86f059-d1bc-4366-bf53-03d58d90ab6d.png)

# Checklist

- [x] Update CHANGELOG.md
