### PR TITLE
allow selecting a pre-defined env via `+` shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format of this file is based on [Keep a Changelog](https://keepachangelog.co
 
 ### Added
 
--
+- Allow selection of one of our three pre-defined environments using a `+`'d argument (#244)
 
 ### Changed
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,13 +249,7 @@ async fn main() {
     // +prod/+production for studio.fiberplane.com
     let maybe_env = cli_args.next();
 
-    let env = maybe_env.as_ref().and_then(|input| {
-        if input.starts_with("+") {
-            Some(&input[1..])
-        } else {
-            None
-        }
-    });
+    let env = maybe_env.as_ref().and_then(|input| input.strip_prefix('+'));
 
     let clap_args: Vec<_> = if let Some(env) = env {
         let base_url = match env {

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,7 +251,7 @@ async fn main() {
 
     let env = maybe_env.as_ref().and_then(|input| input.strip_prefix('+'));
 
-    let clap_args: Vec<_> = if let Some(env) = env {
+    let clap_args = if let Some(env) = env {
         let base_url = match env {
             "prod" | "production" => "https://studio.fiberplane.com",
             "demo" => "https://demo.fiberplane.io",


### PR DESCRIPTION
# Description

allows selection of one of our three pre-defined environments via the same style of shortcut that `cargo` uses. valid arguments are `+dev`, `+demo`, `+prod` and `+production`. examples:

```shell
$ fp notebooks create         # will create a new notebook on production
$ fp +demo notebooks create   # will create a new notebook on demo
$ fp +dev notebooks create    # will create a new notebook on dev
$ fp +prod notebook create    # will create a new notebook on production
```

note that the `+`'d argument needs to be the second argument, right after the program. it doesn't work in any other place, unlike all `clap` commands. this is because this is not a special feature of `clap`, but we have to manually parse it before handing over the rest of the args to `clap`. `cargo` does the same.

this was inspired by a conversation @hatchan and me had a bit less than a year ago.

# Checklist

- [x] Update CHANGELOG.md
