### PR TITLE
introduce profiles allowing different base url's and auth tokens

### DIFF
--- a/src/daemons.rs
+++ b/src/daemons.rs
@@ -11,7 +11,7 @@ use fiberplane::models::names::Name;
 use fiberplane::models::proxies::{NewProxy, Proxy, ProxySummary};
 use petname::petname;
 use serde::Serialize;
-use std::{cmp::Ordering, collections::BTreeMap, path::PathBuf};
+use std::{cmp::Ordering, collections::BTreeMap};
 use tracing::info;
 use url::Url;
 
@@ -61,7 +61,7 @@ pub struct CreateArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -78,7 +78,7 @@ pub struct ListArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -95,7 +95,7 @@ pub struct DataSourcesArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -115,7 +115,7 @@ pub struct GetArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -131,7 +131,7 @@ pub struct DeleteArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 /// A generic output for daemon related commands.
@@ -158,7 +158,7 @@ pub async fn handle_command(args: Arguments) -> Result<()> {
 async fn handle_create_command(args: CreateArgs) -> Result<()> {
     let default_name = Name::new(petname(2, "-")).expect("petname should be valid name");
     let name = name_req("Daemon name", args.name, Some(default_name))?;
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
     let mut new_proxy = NewProxy::builder().name(name).build();
@@ -189,7 +189,7 @@ struct ProxySummaryWithConnectedDataSources {
 }
 
 async fn handle_list_command(args: ListArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let proxies = proxy_list(&client, workspace_id).await?;
     let data_sources = data_source_list(&client, workspace_id).await?;
@@ -249,7 +249,7 @@ async fn handle_list_command(args: ListArgs) -> Result<()> {
 }
 
 async fn handle_get_command(args: GetArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let proxy_name = interactive::proxy_picker(
         &client,
@@ -270,7 +270,7 @@ async fn handle_get_command(args: GetArgs) -> Result<()> {
 }
 
 async fn handle_data_sources_command(args: DataSourcesArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let data_sources = data_source_list(&client, workspace_id).await?;
 
@@ -286,7 +286,7 @@ async fn handle_data_sources_command(args: DataSourcesArgs) -> Result<()> {
 }
 
 async fn handle_delete_command(args: DeleteArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let proxy_name = interactive::proxy_picker(
         &client,

--- a/src/data_sources.rs
+++ b/src/data_sources.rs
@@ -13,7 +13,7 @@ use fiberplane::models::data_sources::{DataSource, NewDataSource, UpdateDataSour
 use fiberplane::models::names::Name;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use std::{path::PathBuf, str::FromStr};
+use std::str::FromStr;
 use url::Url;
 
 #[derive(Parser)]
@@ -95,7 +95,7 @@ struct CreateArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -116,7 +116,7 @@ struct GetArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -133,7 +133,7 @@ struct DeleteArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -162,7 +162,7 @@ struct UpdateArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -179,7 +179,7 @@ struct ListArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 pub async fn handle_command(args: Arguments) -> Result<()> {
@@ -196,7 +196,7 @@ pub async fn handle_command(args: Arguments) -> Result<()> {
 }
 
 async fn handle_create(args: CreateArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let name = name_req("Data source name", args.name, None)?;
@@ -240,7 +240,7 @@ async fn handle_create(args: CreateArgs) -> Result<()> {
 }
 
 async fn handle_delete(args: DeleteArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
     let data_source = data_source_picker(&client, Some(workspace_id), args.name).await?;
@@ -251,7 +251,7 @@ async fn handle_delete(args: DeleteArgs) -> Result<()> {
 }
 
 async fn handle_get(args: GetArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
     let data_source = data_source_picker(&client, Some(workspace_id), args.name).await?;
@@ -266,7 +266,7 @@ async fn handle_get(args: GetArgs) -> Result<()> {
 }
 
 async fn handle_update(args: UpdateArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
     let data_source = data_source_picker(&client, Some(workspace_id), args.name).await?;
@@ -287,7 +287,7 @@ async fn handle_update(args: UpdateArgs) -> Result<()> {
 }
 
 async fn handle_list(args: ListArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
     let data_sources = data_source_list(&client, workspace_id).await?;

--- a/src/events.rs
+++ b/src/events.rs
@@ -10,7 +10,7 @@ use fiberplane::base64uuid::Base64Uuid;
 use fiberplane::models::events::{Event, NewEvent};
 use fiberplane::models::sorting::{EventSortFields, SortDirection};
 use fiberplane::models::timestamps::Timestamp;
-use std::{collections::HashMap, fmt::Display, path::PathBuf};
+use std::{collections::HashMap, fmt::Display};
 use tracing::info;
 use url::Url;
 
@@ -78,7 +78,7 @@ struct CreateArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -123,11 +123,11 @@ pub struct SearchArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_event_create_command(args: CreateArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let key_values: HashMap<_, _> = args
         .labels
@@ -159,7 +159,7 @@ async fn handle_event_create_command(args: CreateArguments) -> Result<()> {
 }
 
 async fn handle_event_search_command(args: SearchArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
@@ -195,11 +195,11 @@ pub struct DeleteArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_event_delete_command(args: DeleteArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     event_delete(&client, args.id).await?;
 

--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -69,7 +69,7 @@ struct MessageArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 
     /// Output type to display
     #[clap(long, short, default_value = "table", value_enum)]
@@ -91,7 +91,7 @@ struct CrawlArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -114,7 +114,7 @@ struct PrometheusGraphToNotebookArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(ValueEnum, Clone)]
@@ -138,7 +138,7 @@ pub async fn handle_command(args: Arguments) -> Result<()> {
 }
 
 async fn handle_message_command(args: MessageArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let notebook_id = interactive::notebook_picker(&client, args.notebook_id, None).await?;
     let mut cache = Cache::load().await?;
 
@@ -214,7 +214,7 @@ async fn handle_crawl_command(args: CrawlArgs) -> Result<()> {
     let mut notebook_titles: HashMap<String, usize> = HashMap::new();
     let mut notebooks_to_crawl = VecDeque::new();
 
-    let client = api_client_configuration(args.config, args.base_url.clone()).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let starting_notebook_id =
         interactive::notebook_picker(&client, args.notebook_id, None).await?;
 
@@ -384,7 +384,7 @@ fn cache_file_path() -> PathBuf {
 }
 
 async fn handle_prometheus_redirect_command(args: PrometheusGraphToNotebookArgs) -> Result<()> {
-    let client = Arc::new(api_client_configuration(args.config, args.base_url).await?);
+    let client = Arc::new(api_client_configuration(args.profile.as_deref()).await?);
     let workspace_id = interactive::workspace_picker(&client, args.workspace_id).await?;
     let notebook_id =
         interactive::notebook_picker(&client, args.notebook_id, Some(workspace_id)).await?;

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -5,7 +5,6 @@ use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use fiberplane::api_client::{label_keys_list, label_values_list};
 use fiberplane::base64uuid::Base64Uuid;
-use std::path::PathBuf;
 use url::Url;
 
 #[derive(Parser)]
@@ -49,7 +48,7 @@ pub struct ListKeysArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(ValueEnum, Clone)]
@@ -62,7 +61,7 @@ enum ListKeysOutput {
 }
 
 async fn handle_list_keys_command(args: ListKeysArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let prefix = interactive::text_opt("Prefix", args.prefix, None);
@@ -94,7 +93,7 @@ pub struct ListValuesArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(ValueEnum, Clone)]
@@ -107,7 +106,7 @@ enum ListValuesOutput {
 }
 
 async fn handle_list_values_command(args: ListValuesArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let label_key = interactive::text_req("Label key", args.label_key, None)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ mod labels;
 mod manifest;
 mod notebooks;
 mod output;
+mod profiles;
 mod providers;
 mod run;
 mod shell;
@@ -77,9 +78,9 @@ pub struct Arguments {
     )]
     base_url: Url,
 
-    /// Path to Fiberplane config file
+    /// Which profile to use
     #[clap(long, global = true, env, help_heading = "Global options")]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 
     /// Disables the version check
     #[clap(long, global = true, env, help_heading = "Global options")]
@@ -211,6 +212,10 @@ enum SubCommand {
     #[clap(aliases = &["webhook", "wh"])]
     Webhooks(webhooks::Arguments),
 
+    /// Profiles allow you to conveniently use different Fiberplane logins with the very same CLI
+    #[clap(alias = "profile")]
+    Profiles(profiles::Arguments),
+
     /// Display extra version information
     #[clap()]
     Version(version::Arguments),
@@ -261,6 +266,11 @@ async fn main() {
         eprintln!("unable to initialize logging: {err:?}");
         process::exit(1);
     };
+
+    if let Err(err) = config::init().await {
+        eprintln!("unable to initialize config file: {err}");
+        process::exit(1);
+    }
 
     // Start the background version check, but skip it when running the `Update`
     // or `Version` command, or if the disable_version_check is set to true.

--- a/src/notebooks.rs
+++ b/src/notebooks.rs
@@ -23,7 +23,6 @@ use fiberplane::models::notebooks::{
 };
 use fiberplane::models::sorting::{NotebookSortFields, SortDirection};
 use fiberplane::models::timestamps::{NewTimeRange, TimeRange, Timestamp};
-use std::path::PathBuf;
 use time::ext::NumericalDuration;
 use tracing::info;
 use url::Url;
@@ -165,11 +164,11 @@ pub struct CreateArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_create_command(args: CreateArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url.clone()).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let labels = args.labels.into_iter().map(Into::into).collect();
@@ -247,11 +246,11 @@ pub struct DuplicateArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_duplicate_command(args: DuplicateArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url.clone()).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let notebook_id = interactive::notebook_picker_with_prompt(
         "Source Notebook",
@@ -319,11 +318,11 @@ pub struct GetArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_get_command(args: GetArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let notebook_id = notebook_picker(&client, args.notebook_id, args.workspace_id).await?;
 
     let notebook = notebook_get(&client, notebook_id).await?;
@@ -355,11 +354,11 @@ pub struct ListArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_list_command(args: ListArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let notebooks = notebook_list(&client, workspace_id).await?;
@@ -407,11 +406,11 @@ pub struct SearchArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_search_command(args: SearchArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let mut search_params = NotebookSearch::default();
@@ -464,11 +463,11 @@ pub struct OpenArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_open_command(args: OpenArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url.clone()).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let notebook_id = notebook_picker(&client, args.notebook_id, None).await?;
 
@@ -496,11 +495,11 @@ pub struct DeleteArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_delete_command(args: DeleteArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let notebook_id = notebook_picker(&client, args.notebook_id, args.workspace_id).await?;
 
     notebook_delete(&client, notebook_id)
@@ -529,7 +528,7 @@ pub struct AppendCellArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 
     /// Output type to display
     #[clap(long, short, default_value = "table", value_enum)]
@@ -537,7 +536,7 @@ pub struct AppendCellArgs {
 }
 
 async fn handle_append_cell_command(args: AppendCellArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let notebook_id = notebook_picker(&client, args.notebook_id, None).await?;
 
     let cell = if let Some(content) = args.text {
@@ -602,11 +601,11 @@ pub struct InsertSnippetArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 pub(crate) async fn handle_insert_snippet_command(args: InsertSnippetArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url.clone()).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker_with_prompt(
         "Workspace of the snippet and notebook",
@@ -674,11 +673,11 @@ struct FrontMatterUpdateArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_front_matter_update_command(args: FrontMatterUpdateArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let notebook_id = notebook_picker(&client, args.notebook_id, Some(workspace_id)).await?;
@@ -703,11 +702,11 @@ struct FrontMatterClearArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_front_matter_clear_command(args: FrontMatterClearArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let notebook_id = notebook_picker(&client, args.notebook_id, Some(workspace_id)).await?;

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -1,0 +1,130 @@
+use crate::config::{default_profile_name, Config, FP_CONFIG_DIR};
+use crate::interactive::{text_opt, text_req};
+use anyhow::{bail, Result};
+use clap::Parser;
+use tracing::info;
+
+#[derive(Parser)]
+pub struct Arguments {
+    #[clap(subcommand)]
+    sub_command: SubCommand,
+}
+
+#[derive(Parser)]
+enum SubCommand {
+    /// Create a new profile
+    Create(CreateArgs),
+
+    /// List all profiles
+    List,
+
+    /// Delete a profile
+    Delete(DeleteArgs),
+
+    /// Set a profile to a default profile
+    SetDefault(UpdateArgs),
+}
+
+pub async fn handle_command(args: Arguments) -> Result<()> {
+    match args.sub_command {
+        SubCommand::Create(args) => handle_profile_create(args).await,
+        SubCommand::List => handle_profile_list().await,
+        SubCommand::Delete(args) => handle_profile_delete(args).await,
+        SubCommand::SetDefault(args) => handle_profile_set_default(args).await,
+    }
+}
+
+#[derive(Parser)]
+struct CreateArgs {
+    /// Name of the new profile. Must be allowed as a file name depending on your file system restrictions
+    #[clap(long)]
+    name: Option<String>,
+
+    /// Endpoint which this profile should contact
+    #[clap(long)]
+    endpoint: Option<String>,
+}
+
+async fn handle_profile_create(args: CreateArgs) -> Result<()> {
+    let name = text_req("Name", args.name, None)?.to_lowercase();
+
+    if name.contains(' ') || name.contains('.') {
+        bail!("Name cannot contain spaces or dots");
+    }
+
+    let endpoint = text_opt(
+        "Endpoint",
+        args.endpoint,
+        Some("https://studio.fiberplane.com".to_string()),
+    );
+
+    let config = Config {
+        api_token: None,
+        endpoint,
+    };
+
+    config.save(Some(&name)).await?;
+
+    info!("Successfully created new profile. Login on that profile with `fp +{name} login`");
+    Ok(())
+}
+
+async fn handle_profile_list() -> Result<()> {
+    info!("List of profiles:");
+
+    for entry in std::fs::read_dir(FP_CONFIG_DIR.as_path())? {
+        let entry = entry?;
+        let file_name = entry.file_name().into_string()?;
+
+        if !file_name.ends_with(".toml") {
+            continue;
+        }
+
+        info!("- {}", file_name.replace(".toml", ""));
+    }
+
+    Ok(())
+}
+
+#[derive(Parser)]
+struct DeleteArgs {
+    /// Name of the profile to delete
+    #[clap(long)]
+    name: Option<String>,
+}
+
+async fn handle_profile_delete(args: DeleteArgs) -> Result<()> {
+    let name = text_req("Name", args.name, None)?.to_lowercase();
+
+    if name == default_profile_name().await? {
+        bail!("Cannot delete default profile. Please switch it first with `fp profile set-default`")
+    }
+
+    tokio::fs::remove_file(FP_CONFIG_DIR.join(format!("{name}.toml"))).await?;
+
+    info!("Successfully deleted profile.");
+    Ok(())
+}
+
+#[derive(Parser)]
+struct SetDefaultArgs {
+    /// Name of the profile to make default
+    #[clap(long)]
+    name: Option<String>,
+}
+
+async fn handle_profile_set_default(args: SetDefaultArgs) -> Result<()> {
+    let name = text_req("Name", args.name, None)?.to_lowercase();
+
+    if tokio::fs::metadata(FP_CONFIG_DIR.join(format!("{name}.toml")))
+        .await
+        .is_err()
+    {
+        bail!("Profile not found");
+    }
+
+    tokio::fs::write(FP_CONFIG_DIR.join("default_profile"), name).await?;
+
+    info!("Successfully set default profile to {name}");
+    Ok(())
+}

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -1,6 +1,6 @@
 use crate::config::{default_profile_name, Config, FP_CONFIG_DIR};
 use crate::interactive::{text_opt, text_req};
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use clap::Parser;
 use tracing::info;
 
@@ -22,7 +22,7 @@ enum SubCommand {
     Delete(DeleteArgs),
 
     /// Set a profile to a default profile
-    SetDefault(UpdateArgs),
+    SetDefault(SetDefaultArgs),
 }
 
 pub async fn handle_command(args: Arguments) -> Result<()> {
@@ -74,7 +74,10 @@ async fn handle_profile_list() -> Result<()> {
 
     for entry in std::fs::read_dir(FP_CONFIG_DIR.as_path())? {
         let entry = entry?;
-        let file_name = entry.file_name().into_string()?;
+        let file_name = entry
+            .file_name()
+            .into_string()
+            .map_err(|_| anyhow!("failed to convert osstring to str"))?;
 
         if !file_name.ends_with(".toml") {
             continue;
@@ -125,6 +128,6 @@ async fn handle_profile_set_default(args: SetDefaultArgs) -> Result<()> {
 
     tokio::fs::write(FP_CONFIG_DIR.join("default_profile"), name).await?;
 
-    info!("Successfully set default profile to {name}");
+    info!("Successfully set default profile");
     Ok(())
 }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -8,7 +8,7 @@ use fiberplane::base64uuid::Base64Uuid;
 use fiberplane::models::notebooks::Cell;
 use futures::StreamExt;
 use std::io::ErrorKind;
-use std::{env, path::PathBuf, process::Stdio};
+use std::{env, process::Stdio};
 use tokio::io::{self, AsyncWriteExt};
 use tokio::{process::Command, signal};
 use tokio_util::io::ReaderStream;
@@ -36,7 +36,7 @@ pub struct Arguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 
     /// Output type to display
     #[clap(long, short, default_value = "command", value_enum)]
@@ -56,7 +56,7 @@ enum ExecOutput {
 }
 
 pub async fn handle_command(args: Arguments) -> Result<()> {
-    let client = api_client_configuration(args.config.clone(), args.base_url.clone()).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let command = args.command.join(" ");
 
     let workspace_id = interactive::workspace_picker(&client, args.workspace_id).await?;

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -9,7 +9,6 @@ use crate::interactive;
 use anyhow::Result;
 use clap::Parser;
 use fiberplane::base64uuid::Base64Uuid;
-use std::path::PathBuf;
 use std::time::Duration;
 use tracing::instrument;
 
@@ -31,7 +30,7 @@ pub struct Arguments {
     base_url: url::Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 const TEXT_BUF_SIZE: usize = 256;
@@ -44,7 +43,7 @@ pub(crate) async fn handle_command(args: Arguments) -> Result<()> {
         ));
     }
 
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let notebook_id = interactive::notebook_picker(&client, args.notebook_id, None).await?;
 
     let launcher = ShellLauncher::new(notebook_id.into());

--- a/src/snippets.rs
+++ b/src/snippets.rs
@@ -104,7 +104,7 @@ struct ConvertArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -140,7 +140,7 @@ struct CreateArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -167,7 +167,7 @@ struct GetArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -183,7 +183,7 @@ struct DeleteArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser, Debug)]
@@ -208,7 +208,7 @@ struct ListArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -240,7 +240,7 @@ struct UpdateArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -285,7 +285,7 @@ pub async fn handle_command(args: Arguments) -> Result<()> {
 }
 
 async fn handle_convert(args: ConvertArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let notebook_id = notebook_picker(&client, args.notebook_id, Some(workspace_id)).await?;
     let notebook = notebook_get(&client, notebook_id).await?;
@@ -370,7 +370,7 @@ async fn handle_convert(args: ConvertArguments) -> Result<()> {
 }
 
 async fn handle_create(args: CreateArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let name = name_opt(
@@ -402,7 +402,7 @@ async fn handle_create(args: CreateArguments) -> Result<()> {
 }
 
 async fn handle_delete(args: DeleteArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let (workspace_id, snippet_name) = snippet_picker(&client, args.snippet_name, None).await?;
 
@@ -415,7 +415,7 @@ async fn handle_delete(args: DeleteArguments) -> Result<()> {
 }
 
 async fn handle_list(args: ListArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
@@ -437,7 +437,7 @@ async fn handle_list(args: ListArguments) -> Result<()> {
 }
 
 async fn handle_get(args: GetArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let (workspace_id, snippet_name) = snippet_picker(&client, args.snippet_name, None).await?;
     let snippet = snippet_get(&client, workspace_id, &snippet_name).await?;
@@ -453,7 +453,7 @@ async fn handle_get(args: GetArguments) -> Result<()> {
 }
 
 async fn handle_update(args: UpdateArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let (workspace_id, snippet_name) =
         snippet_picker(&client, args.snippet_name, args.workspace_id).await?;

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -143,7 +143,7 @@ struct ExpandArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -189,7 +189,7 @@ struct ConvertArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -232,7 +232,7 @@ struct CreateArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -259,7 +259,7 @@ struct GetArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -275,7 +275,7 @@ struct DeleteArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser, Debug)]
@@ -300,7 +300,7 @@ struct ListArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -332,7 +332,7 @@ struct UpdateArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -437,7 +437,7 @@ async fn load_template(template_path: &str) -> Result<String> {
 async fn handle_expand_command(args: ExpandArguments) -> Result<()> {
     let base_url = args.base_url.clone();
 
-    let client = api_client_configuration(args.config.clone(), base_url.clone()).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let template_url_base = base_url.join(&format!("workspaces/{workspace_id}/templates/"))?;
 
@@ -468,7 +468,7 @@ async fn expand_template_api(
     workspace_id: Base64Uuid,
     template_name: Name,
 ) -> Result<Notebook> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let notebook = template_expand(
         &client,
@@ -489,7 +489,7 @@ async fn expand_template_api(
 async fn expand_template_file(args: ExpandArguments, workspace_id: Base64Uuid) -> Result<Notebook> {
     let template = load_template(&args.template).await?;
 
-    let client = api_client_configuration(args.config, args.base_url.clone()).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let template_args = if let Some(args) = args.template_arguments {
         args.0
@@ -508,7 +508,7 @@ async fn expand_template_file(args: ExpandArguments, workspace_id: Base64Uuid) -
 
 async fn handle_convert_command(args: ConvertArguments) -> Result<()> {
     // Load the notebook
-    let client = api_client_configuration(args.config.clone(), args.base_url.clone()).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let notebook_id =
         interactive::notebook_picker(&client, args.notebook_id, Some(workspace_id)).await?;
@@ -605,7 +605,7 @@ async fn handle_convert_command(args: ConvertArguments) -> Result<()> {
 }
 
 async fn handle_create_command(args: CreateArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let name = interactive::name_opt(
@@ -641,7 +641,7 @@ async fn handle_create_command(args: CreateArguments) -> Result<()> {
 }
 
 async fn handle_get_command(args: GetArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let (workspace_id, template_name) =
         interactive::template_picker(&client, args.template_name, None).await?;
 
@@ -658,7 +658,7 @@ async fn handle_get_command(args: GetArguments) -> Result<()> {
 }
 
 async fn handle_delete_command(args: DeleteArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let (workspace_id, template_name) =
         interactive::template_picker(&client, args.template_name, None).await?;
 
@@ -673,7 +673,7 @@ async fn handle_delete_command(args: DeleteArguments) -> Result<()> {
 async fn handle_list_command(args: ListArguments) -> Result<()> {
     debug!("handle list command");
 
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
     let templates = template_list(
@@ -694,7 +694,7 @@ async fn handle_list_command(args: ListArguments) -> Result<()> {
 }
 
 async fn handle_update_command(args: UpdateArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let (workspace_id, template_name) =
         interactive::template_picker(&client, args.template_name, args.workspace_id).await?;
 

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -7,7 +7,6 @@ use fiberplane::api_client::{token_create, token_delete, token_list};
 use fiberplane::base64uuid::Base64Uuid;
 use fiberplane::models::sorting::{SortDirection, TokenListSortFields};
 use fiberplane::models::tokens::{NewToken, Token, TokenSummary};
-use std::path::PathBuf;
 use time::format_description::well_known::Rfc3339;
 use tracing::info;
 use url::Url;
@@ -76,7 +75,7 @@ struct CreateArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -105,7 +104,7 @@ pub struct ListArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -117,11 +116,11 @@ pub struct DeleteArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_token_create_command(args: CreateArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let token = token_create(&client, NewToken::new(args.name)).await?;
 
@@ -140,7 +139,7 @@ async fn handle_token_create_command(args: CreateArguments) -> Result<()> {
 }
 
 async fn handle_token_list_command(args: ListArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let tokens = token_list(
         &client,
@@ -161,7 +160,7 @@ async fn handle_token_list_command(args: ListArguments) -> Result<()> {
 }
 
 async fn handle_token_delete_command(args: DeleteArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     token_delete(&client, args.id).await?;
 

--- a/src/triggers.rs
+++ b/src/triggers.rs
@@ -16,7 +16,6 @@ use fiberplane::models::notebooks::{
 };
 use serde_json::Map;
 use std::iter::FromIterator;
-use std::path::PathBuf;
 use tracing::info;
 use url::Url;
 
@@ -84,7 +83,7 @@ struct CreateArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -100,7 +99,7 @@ struct GetArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -112,7 +111,7 @@ struct DeleteArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -129,7 +128,7 @@ struct ListArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -155,7 +154,7 @@ struct InvokeArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 /// A generic output for trigger related commands.
@@ -169,7 +168,7 @@ enum TriggerOutput {
 }
 
 async fn handle_trigger_create_command(args: CreateArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url.clone()).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = interactive::workspace_picker(&client, args.workspace_id).await?;
     let (_, template_name) =
@@ -199,7 +198,7 @@ async fn handle_trigger_create_command(args: CreateArguments) -> Result<()> {
 }
 
 async fn handle_trigger_get_command(args: GetArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url.clone()).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let trigger_id = interactive::trigger_picker(&client, args.trigger_id, None).await?;
 
     let trigger = trigger_get(&client, trigger_id)
@@ -215,7 +214,7 @@ async fn handle_trigger_get_command(args: GetArguments) -> Result<()> {
 }
 
 async fn handle_trigger_delete_command(args: DeleteArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let trigger_id = interactive::trigger_picker(&client, args.trigger_id, None).await?;
 
     trigger_delete(&client, trigger_id)
@@ -228,7 +227,7 @@ async fn handle_trigger_delete_command(args: DeleteArguments) -> Result<()> {
 }
 
 async fn handle_trigger_list_command(args: ListArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = interactive::workspace_picker(&client, args.workspace_id).await?;
     let mut triggers = trigger_list(&client, workspace_id)
         .await
@@ -247,7 +246,7 @@ async fn handle_trigger_list_command(args: ListArguments) -> Result<()> {
 }
 
 async fn handle_trigger_invoke_command(args: InvokeArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url.clone()).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let trigger_id = interactive::trigger_picker(&client, args.trigger_id, None).await?;
     let secret_key = interactive::text_req("Secret Key", args.secret_key, None)?;
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -3,7 +3,6 @@ use anyhow::{anyhow, Result};
 use clap::Parser;
 use indicatif::{ProgressBar, ProgressStyle};
 use sha2::{Digest, Sha256};
-use std::env;
 use std::fs::OpenOptions;
 use std::io::{BufWriter, Write};
 use tracing::{debug, info};

--- a/src/users.rs
+++ b/src/users.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use fiberplane::api_client::profile_get;
 use fiberplane::models::users::Profile;
-use std::path::PathBuf;
 use url::Url;
 
 #[derive(Parser)]
@@ -38,7 +37,7 @@ struct GetArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 pub async fn handle_command(args: Arguments) -> Result<()> {
@@ -48,7 +47,7 @@ pub async fn handle_command(args: Arguments) -> Result<()> {
 }
 
 async fn handle_get_profile_command(args: GetArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let profile = profile_get(&client).await?;
 
     match args.output {

--- a/src/views.rs
+++ b/src/views.rs
@@ -13,7 +13,6 @@ use fiberplane::models::names::Name;
 use fiberplane::models::sorting::{NotebookSortFields, SortDirection, ViewSortFields};
 use fiberplane::models::views::{NewView, RelativeTime, TimeUnit, UpdateView, View};
 use std::fmt::Display;
-use std::path::PathBuf;
 use time::format_description::well_known::Rfc3339;
 use tracing::info;
 use url::Url;
@@ -97,11 +96,11 @@ struct CreateArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_create(args: CreateArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let name = name_opt("Name", args.name, None).unwrap();
@@ -167,11 +166,11 @@ struct ListArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_list(args: ListArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
@@ -208,11 +207,11 @@ struct DeleteArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_delete(args: DeleteArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let view_name = view_picker(&client, args.workspace_id, args.view_name).await?;
@@ -295,11 +294,11 @@ struct UpdateArguments {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_update(args: UpdateArguments) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let view_name = view_picker(&client, args.workspace_id, args.view_name).await?;

--- a/src/webhooks.rs
+++ b/src/webhooks.rs
@@ -16,7 +16,6 @@ use fiberplane::base64uuid::Base64Uuid;
 use fiberplane::models::webhooks::{
     NewWebhook, UpdateWebhook, Webhook, WebhookCategory, WebhookDelivery, WebhookDeliverySummary,
 };
-use std::path::PathBuf;
 use time::format_description::well_known::Rfc3339;
 use tracing::{info, warn};
 use url::Url;
@@ -99,11 +98,11 @@ struct CreateArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_webhook_create(args: CreateArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let categories = webhook_category_picker(args.categories)?;
@@ -157,11 +156,11 @@ struct ListArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_webhook_list(args: ListArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
     let webhooks = webhooks_list(&client, workspace_id, args.page, args.limit).await?;
@@ -189,11 +188,11 @@ struct DeleteArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_webhook_delete(args: DeleteArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let webhook_id = webhook_picker(&client, workspace_id, args.webhook_id).await?;
@@ -246,11 +245,11 @@ struct UpdateArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_webhook_update(args: UpdateArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let webhook_id = webhook_picker(&client, workspace_id, args.webhook_id).await?;
@@ -312,11 +311,11 @@ struct WebhookDeliveryListArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_webhook_delivery_list(args: WebhookDeliveryListArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let webhook_id = webhook_picker(&client, workspace_id, args.webhook_id).await?;
@@ -356,11 +355,11 @@ struct WebhookDeliveryInfoArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_webhook_delivery_info(args: WebhookDeliveryInfoArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let webhook_id = webhook_picker(&client, workspace_id, args.webhook_id).await?;
@@ -411,11 +410,11 @@ struct WebhookDeliveryResendArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_webhook_delivery_resend(args: WebhookDeliveryResendArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let webhook_id = webhook_picker(&client, workspace_id, args.webhook_id).await?;

--- a/src/workspaces.rs
+++ b/src/workspaces.rs
@@ -25,7 +25,7 @@ use fiberplane::models::workspaces::{
     WorkspaceInvite, WorkspaceInviteResponse, WorkspaceUserUpdate,
 };
 use std::collections::BTreeMap;
-use std::{fmt::Display, path::PathBuf};
+use std::fmt::Display;
 use tracing::info;
 use url::Url;
 
@@ -145,11 +145,11 @@ struct CreateArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_workspace_create(args: CreateArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let name = name_opt("Unique workspace name", args.name, None)
         .ok_or_else(|| anyhow!("Name is required"))?;
@@ -182,11 +182,11 @@ struct DeleteArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_workspace_delete(args: DeleteArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
     workspace_delete(&client, workspace_id).await?;
@@ -221,11 +221,11 @@ struct ListArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_workspace_list(args: ListArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let list = workspace_list(
         &client,
@@ -253,11 +253,11 @@ struct LeaveArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_workspace_leave(args: LeaveArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
     workspace_leave(&client, workspace_id).await?;
@@ -288,11 +288,11 @@ struct InviteCreateArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_invite_create(args: InviteCreateArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let email = text_req("Email", args.email, None)?;
 
@@ -347,11 +347,11 @@ struct InviteListArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_invite_list(args: InviteListArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
     let invites = workspace_invite_get(
@@ -383,11 +383,11 @@ struct InviteDeleteArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_invite_delete(args: InviteDeleteArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     workspace_invite_delete(&client, args.invite_id).await?;
 
@@ -425,11 +425,11 @@ struct UserListArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_user_list(args: UserListArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
     let users = workspace_users_list(
@@ -467,11 +467,11 @@ struct UserUpdateArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_user_update(args: UserUpdateArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let user = workspace_user_picker(&client, &workspace_id, args.user_id).await?;
@@ -500,11 +500,11 @@ struct UserDeleteArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_user_delete(args: UserDeleteArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
 
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
     let user = workspace_user_picker(&client, &workspace_id, args.user_id).await?;
@@ -541,7 +541,7 @@ struct MoveOwnerArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -557,7 +557,7 @@ struct ChangeNameArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -585,7 +585,7 @@ pub(crate) struct GetDefaultDataSourcesArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -605,7 +605,7 @@ pub(crate) struct SetDefaultDataSourcesArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 #[derive(Parser)]
@@ -621,11 +621,11 @@ pub(crate) struct UnsetDefaultDataSourcesArgs {
     base_url: Url,
 
     #[clap(from_global)]
-    config: Option<PathBuf>,
+    profile: Option<String>,
 }
 
 async fn handle_move_owner(args: MoveOwnerArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
     let new_owner = workspace_user_picker(&client, &workspace_id, args.new_owner_id).await?;
@@ -642,7 +642,7 @@ async fn handle_move_owner(args: MoveOwnerArgs) -> Result<()> {
 }
 
 async fn handle_change_name(args: ChangeNameArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
     workspace_update(
@@ -659,7 +659,7 @@ async fn handle_change_name(args: ChangeNameArgs) -> Result<()> {
 }
 
 async fn handle_get_default_data_sources(args: GetDefaultDataSourcesArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
     let default_data_sources = workspace_get(&client, workspace_id)
@@ -677,7 +677,7 @@ async fn handle_get_default_data_sources(args: GetDefaultDataSourcesArgs) -> Res
 }
 
 async fn handle_set_default_data_source(args: SetDefaultDataSourcesArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
     let data_source =
@@ -721,7 +721,7 @@ async fn handle_set_default_data_source(args: SetDefaultDataSourcesArgs) -> Resu
 }
 
 async fn handle_unset_default_data_source(args: UnsetDefaultDataSourcesArgs) -> Result<()> {
-    let client = api_client_configuration(args.config, args.base_url).await?;
+    let client = api_client_configuration(args.profile.as_deref()).await?;
     let workspace_id = workspace_picker(&client, args.workspace_id).await?;
 
     let mut default_data_sources = workspace_get(&client, workspace_id)


### PR DESCRIPTION
# Description

can be used with the well known cargo notation of `+<profile name>`, example: `fp +profile2 workspaces list` or `fp +profile3 notebook create`

replaces #244

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [ ] Update CHANGELOG.md
