### PR TITLE
Add build target for linux/arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,12 +37,16 @@ jobs:
       RUST_BACKTRACE: 1
     strategy:
       matrix:
-        build: [linux_x86_64, macos_x86_64, macos_aarch64]
+        build: [linux_x86_64, linux_aarch64, macos_x86_64, macos_aarch64]
         include:
           - build: linux_x86_64
             os: ubuntu-latest
             rust: stable
             target: x86_64-unknown-linux-gnu
+          - build: linux_aarch64
+            os: ubuntu-latest
+            rust: stable
+            target: aarch64-unknown-linux-gnu
           - build: macos_x86_64
             os: macOS-11
             rust: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format of this file is based on [Keep a Changelog](https://keepachangelog.co
 
 ### Added
 
--
+- Added builds for Linux ARM64
 
 ### Changed
 


### PR DESCRIPTION
# Description

This PR adds a build target for linux/arm64 🎉

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] Update CHANGELOG.md
