### PR TITLE
Be explicit about strum version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ rmpv = { version = "1.0.0", features = ["serde"] }
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10.2"
-strum = "*" # follows what fiberplane uses so star is fine
+strum = "0.24" # match what fiberplane-models uses
 sysinfo = "0.27.7"
 termwiz = "0.19.0"
 time = { version = "0.3.11", features = ["macros"] }


### PR DESCRIPTION
# Description

It seems the asterisk can lead to version mismatches when running `cargo update`, so better to be explicit.

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- ~~[ ] Update CHANGELOG.md~~
