### PR TITLE
Bump minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format of this file is based on [Keep a Changelog](https://keepachangelog.co
 
 ## [Unreleased]
 
-## [2.16.0]
+## [2.17.0]
 
 - Fixed an issue with CLI argument completion failing. (#264)
 
-## [2.15.0]
+## [2.16.0]
 
 - Update all dependencies, except `hyper` (#260)
 - Allow overriding the token through an argument or envvar (#261)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format of this file is based on [Keep a Changelog](https://keepachangelog.co
 
 ## [2.16.0]
 
+- Fixed an issue with CLI argument completion failing. (#264)
+
+## [2.15.0]
+
 - Update all dependencies, except `hyper` (#260)
 - Allow overriding the token through an argument or envvar (#261)
 - Replace Lint code in our CI with Clippy+reviewdog (#262)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fp"
-version = "2.16.0"
+version = "2.17.0"
 authors = ["Team Fiberplane"]
 edition = "2018"
 build = "build.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fp"
-version = "2.17.0"
+version = "2.18.0"
 authors = ["Team Fiberplane"]
 edition = "2018"
 build = "build.rs"
@@ -76,7 +76,14 @@ webbrowser = "0.8.7"
 
 [build-dependencies]
 anyhow = "1.0"
-vergen = { version = "8.0.0", features = ["build", "cargo", "git", "gitcl", "rustc", "si"] }
+vergen = { version = "8.0.0", features = [
+    "build",
+    "cargo",
+    "git",
+    "gitcl",
+    "rustc",
+    "si",
+] }
 
 [patch.crates-io]
 # fiberplane = { git = "ssh://git@github.com/fiberplane/fiberplane.git", branch = "main" }


### PR DESCRIPTION
This PR bumps the version numbers so they match the next release.
Please verify the version numbers are correct, and update the CHANGELOG manually. You
should merge this PR ASAP, but no later than before the next release cycle starts.

# Checklist

- [x] Version numbers are correct
- [x] `CHANGELOG.md` has been updated