### PR TITLE
Bump minor version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fp"
-version = "2.18.0"
+version = "2.19.0"
 authors = ["Team Fiberplane"]
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
This PR bumps the version numbers so they match the next release.
Please verify the version numbers are correct, and update the CHANGELOG manually. You
should merge this PR ASAP, but no later than before the next release cycle starts.

# Checklist

- [ ] Version numbers are correct
- [ ] `CHANGELOG.md` has been updated