### PR TITLE
Add subcommands to manipulate front matter in notebooks and collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,27 @@ The format of this file is based on [Keep a Changelog](https://keepachangelog.co
 
 ## [Unreleased]
 
+### Added
+- Add `integrations list` command (#267)
+- Add `front-matter-collection get` command (#271)
+- Add `front-matter-collection set` command (#271)
+- Add `front-matter-collection create` command (#271)
+- Add `notebook front-matter append` command (#271)
+- Add `notebook front-matter edit` command (#271)
+- Add `notebook front-matter delete` command (#271)
+
+### Deprecated
+
+- `notebook front-matter update` will not work as expected with the new front matter
+  most of the time, and therefore it is deprecated. Use the new
+  `notebook front-matter edit` instead (#271)
+- `notebook front-matter clear` will not work as expected with the new front matter
+  most of the time, therefore it is deprecated. Use the new
+  `notebook front-matter delete` with the `--all` flag instead (#271)
+
 ## [2.19.0]
 
 - Update fiberplane dependencies
-- Add `integrations list` command (#267)
 
 ## [2.18.0]
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,81 @@ The CLI also supports the following operations for your (organization's) trigger
 - `fp triggers get <id>`
 - `fp triggers delete <id>`
 
+### Front Matter Collections
+
+The CLI allows to manage the front matter collections of a workspace, so that common front matter
+fields can easily be grouped for integration in notebooks. The subcommand for these is `fp front-matter-collections`, which
+can be shortened to `fp fmc`. Check `fp fmc help` to see all the available subcommands
+
+#### Creating a front matter collection
+
+All the parameters that are not specified in the command line will be prompted by the CLI when creating
+a front matter collection.
+
+``` shell
+fp fmc create path/to/schema.json
+```
+
+An example of the format of the expected JSON (it follows the API format from the common models of fiberplane):
+
+``` json
+[
+    {
+        "key": "incident.commander",
+        "schema": {
+            "type": "user",
+            "displayName": "Commander"
+        }
+    },
+    {
+        "key": "incident.status",
+        "schema": {
+            "type": "string",
+            "displayName": "Status",
+            "options": [
+                {"value": "started"},
+                {"value": "detected"},
+                {"value": "root cause found"},
+                {"value": "patch applied"},
+                {"value": "resolved"}
+            ]
+        }
+    },
+    {
+        "key": "incident.ebit-loss",
+        "schema": {
+            "type": "number",
+            "displayName": "EBIT loss",
+            "suffix": "EUR"
+        }
+    },
+    {
+        "key": "incident.affected-slos",
+        "schema": {
+            "type": "string",
+            "displayName": "Affected SLOs",
+            "multiple": true,
+            "allowExtraValues": true,
+            "options": [
+                {"value": "API latency"},
+                {"value": "Payment success rate"}
+            ]
+        }
+    }
+]
+```
+
+#### Fetching a front matter collection
+
+A good way to modify a front matter collection is to fetch the current version to modify only the relevant
+fields in the received JSON. The way to get a front matter collection is to use the `get` subcommand:
+
+```shell
+fp fmc get
+```
+
+Just as all other commands within `fp`, the CLI will prompt you for all the missing informations to complete the query.
+
 ### Notebooks
 
 The CLI allows for management for management of your notebooks. Currently the
@@ -123,6 +198,7 @@ following commands are supported:
 
 - `fp notebooks add`
 - `fp notebooks get <id>`
+- `fp notebooks front-matter ...`
 
 #### Creating a new notebook
 
@@ -139,6 +215,24 @@ It is also possible to retrieve the notebook and display it as JSON.
 
 ```shell
 fp notebooks get <notebook_id>
+```
+
+#### Manipulating front matter
+
+It is possible to manipulate the front matter of notebooks programmatically using the `front-matter`
+subcommand of notebook. Check all the options out using:
+
+``` shell
+fp notebooks front-matter help
+```
+
+Examples include:
+
+``` shell
+# Edit a front matter entry in an existing notebook
+fp notebook front-matter edit --front-matter-key severity --new-value info
+# Append the "incident" collection to an existing notebook
+fp nb fm add-collection --name incident
 ```
 
 ## Getting Help

--- a/src/front_matter.rs
+++ b/src/front_matter.rs
@@ -1,0 +1,233 @@
+use std::{io::stdin, path::PathBuf};
+
+use anyhow::{Context, Result};
+use clap::{Parser, ValueHint};
+use fiberplane::{
+    api_client::{
+        workspace_front_matter_schemas_create, workspace_front_matter_schemas_get_by_name,
+    },
+    base64uuid::Base64Uuid,
+    models::{
+        front_matter_schemas::FrontMatterSchema, names::Name,
+        workspaces::NewWorkspaceFrontMatterSchema,
+    },
+};
+use url::Url;
+
+use crate::{
+    config::api_client_configuration,
+    interactive::{front_matter_collection_picker, workspace_picker},
+};
+
+#[derive(Parser)]
+pub struct Arguments {
+    #[clap(subcommand)]
+    sub_command: SubCommand,
+}
+
+#[derive(Parser)]
+pub enum SubCommand {
+    /// Set an existing front matter collection with the given name to the given schema
+    Set(SetArgs),
+
+    /// Create a front matter collection with the given name and the given schema
+    Create(CreateArgs),
+
+    /// Get the front matter collection with the given name
+    Get(GetArgs),
+
+    /// Delete the front matter collection with the given name
+    Delete(DeleteArgs),
+}
+
+#[derive(Parser)]
+pub struct SetArgs {
+    /// Workspace to use
+    #[clap(from_global)]
+    workspace_id: Option<Base64Uuid>,
+
+    /// Name of the front matter collection to set.
+    #[clap(short, long)]
+    name: Option<Name>,
+
+    /// Path to the json file containing the collection description.
+    ///
+    /// Use `-` to read from stdin
+    #[clap(value_hint = ValueHint::FilePath)]
+    json_path: PathBuf,
+
+    #[clap(from_global)]
+    base_url: Url,
+
+    #[clap(from_global)]
+    config: Option<PathBuf>,
+
+    #[clap(from_global)]
+    token: Option<String>,
+}
+
+#[derive(Parser)]
+pub struct CreateArgs {
+    /// Workspace to use
+    #[clap(from_global)]
+    workspace_id: Option<Base64Uuid>,
+
+    /// Name of the front matter collection to create.
+    #[clap(short, long)]
+    name: Name,
+
+    /// Path to the json file containing the collection description.
+    ///
+    /// Use `-` to read from stdin
+    #[clap(value_hint = ValueHint::FilePath)]
+    json_path: PathBuf,
+
+    #[clap(from_global)]
+    base_url: Url,
+
+    #[clap(from_global)]
+    config: Option<PathBuf>,
+
+    #[clap(from_global)]
+    token: Option<String>,
+}
+
+#[derive(Parser)]
+pub struct GetArgs {
+    /// Workspace to use
+    #[clap(from_global)]
+    workspace_id: Option<Base64Uuid>,
+
+    /// Name of the front matter collection to set.
+    #[clap(short, long)]
+    name: Option<Name>,
+
+    #[clap(from_global)]
+    base_url: Url,
+
+    #[clap(from_global)]
+    config: Option<PathBuf>,
+
+    #[clap(from_global)]
+    token: Option<String>,
+}
+
+#[derive(Parser)]
+pub struct DeleteArgs {
+    /// Workspace to use
+    #[clap(from_global)]
+    workspace_id: Option<Base64Uuid>,
+
+    /// Name of the front matter collection to set.
+    #[clap(short, long)]
+    name: Option<Name>,
+
+    #[clap(from_global)]
+    base_url: Url,
+
+    #[clap(from_global)]
+    config: Option<PathBuf>,
+
+    #[clap(from_global)]
+    token: Option<String>,
+}
+
+pub async fn handle_command(args: Arguments) -> Result<()> {
+    match args.sub_command {
+        SubCommand::Set(args) => handle_set_command(args).await,
+        SubCommand::Create(args) => handle_create_command(args).await,
+        SubCommand::Get(args) => handle_get_command(args).await,
+        SubCommand::Delete(args) => handle_delete_command(args).await,
+    }
+}
+
+pub async fn handle_set_command(args: SetArgs) -> Result<()> {
+    let client = api_client_configuration(args.token, args.config, args.base_url.clone()).await?;
+
+    let (workspace_id, fmc_name) =
+        front_matter_collection_picker(&client, args.workspace_id, args.name).await?;
+
+    let front_matter_schema: FrontMatterSchema = if args.json_path.to_str().unwrap() == "-" {
+        let content: String = stdin()
+            .lines()
+            .collect::<Result<_, _>>()
+            .with_context(|| "cannot read content from stdin")?;
+        serde_json::from_str(&content).with_context(|| "cannot parse content as schema")?
+    } else {
+        let content: String = std::fs::read_to_string(&args.json_path)
+            .with_context(|| "cannot open source file for collection")?;
+        serde_json::from_str(&content).with_context(|| "cannot parse content as schema")?
+    };
+
+    workspace_front_matter_schemas_create(
+        &client,
+        workspace_id,
+        NewWorkspaceFrontMatterSchema::builder()
+            .name(fmc_name.to_string())
+            .schema(front_matter_schema)
+            .build(),
+    )
+    .await?;
+
+    Ok(())
+}
+
+pub async fn handle_create_command(args: CreateArgs) -> Result<()> {
+    let client = api_client_configuration(args.token, args.config, args.base_url.clone()).await?;
+
+    let workspace_id = workspace_picker(&client, args.workspace_id).await?;
+
+    let front_matter_schema: FrontMatterSchema = if args.json_path.to_str().unwrap() == "-" {
+        let content: String = stdin()
+            .lines()
+            .collect::<Result<_, _>>()
+            .with_context(|| "cannot read content from stdin")?;
+        serde_json::from_str(&content).with_context(|| "cannot parse content as schema")?
+    } else {
+        let content: String = std::fs::read_to_string(&args.json_path)
+            .with_context(|| "cannot open source file for collection")?;
+        serde_json::from_str(&content).with_context(|| "cannot parse content as schema")?
+    };
+
+    workspace_front_matter_schemas_create(
+        &client,
+        workspace_id,
+        NewWorkspaceFrontMatterSchema::builder()
+            .name(args.name.to_string())
+            .schema(front_matter_schema)
+            .build(),
+    )
+    .await?;
+
+    Ok(())
+}
+
+pub async fn handle_get_command(args: GetArgs) -> Result<()> {
+    let client = api_client_configuration(args.token, args.config, args.base_url.clone()).await?;
+
+    let (workspace_id, fmc_name) =
+        front_matter_collection_picker(&client, args.workspace_id, args.name).await?;
+
+    let fmc = workspace_front_matter_schemas_get_by_name(&client, workspace_id, &fmc_name).await?;
+
+    println!(
+        "{}",
+        serde_json::to_string(&fmc).expect("Front Matter Collections are JSON-serializable")
+    );
+
+    Ok(())
+}
+
+pub async fn handle_delete_command(args: DeleteArgs) -> Result<()> {
+    let client = api_client_configuration(args.token, args.config, args.base_url.clone()).await?;
+
+    let (_workspace_id, _fmc_name) =
+        front_matter_collection_picker(&client, args.workspace_id, args.name).await?;
+
+    unimplemented!(
+        "The workspace_front_matter_schemas_delete endpoint is missing from the API for now."
+    );
+    // workspace_front_matter_schemas_delete(&client, workspace_id, &fmc_name).await?;
+
+    // Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ mod data_sources;
 mod events;
 mod experiments;
 mod fp_urls;
+mod front_matter;
 mod integrations;
 mod interactive;
 mod labels;
@@ -142,6 +143,13 @@ enum SubCommand {
     /// Notebooks are the main resource that Studio exposes.
     #[clap(aliases = &["notebook", "nb"])]
     Notebooks(notebooks::Arguments),
+
+    /// Interact with front matter collections
+    ///
+    /// Front matter collections are pre-determined sets of front matter metadata
+    /// that is used to attach metadata to notebooks.
+    #[clap(aliases = &["fmc", "frontmatter"])]
+    FrontMatterCollection(front_matter::Arguments),
 
     /// Interact with providers
     ///
@@ -305,6 +313,7 @@ async fn main() {
         Labels(args) => labels::handle_command(args).await,
         New(args) => handle_new_command(args).await,
         Notebooks(args) => notebooks::handle_command(args).await,
+        FrontMatterCollection(args) => front_matter::handle_command(args).await,
         Providers(args) => providers::handle_command(args).await,
         Daemons(args) => daemons::handle_command(args).await,
         Run(args) => run::handle_command(args).await,

--- a/src/notebooks.rs
+++ b/src/notebooks.rs
@@ -801,7 +801,7 @@ struct FrontMatterAppendArguments {
     multiple: bool,
 
     /// An optional initial value to set for the appended row.
-    #[clap(long, short, value_parser = parse_from_str)]
+    #[clap(long)]
     value: Option<Value>,
 
     /// Notebook for which front matter should be updated for


### PR DESCRIPTION
# Description

Add an extra subcommand `front-matter-collection/fmc` to `fp` that allows manipulating the front matter
collections in a given workspace. Deletion is not implemented yet because the endpoint to do the manipulation
with the API does not exist yet (and therefore isn’t available in the client).

Add extra front matter related subcommands within `fp notebook fm` that manipulate the front matter
granularly instead of acting in bulk.

Resolves: FP-3487

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] Update CHANGELOG.md
