### PR TITLE
Bump minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format of this file is based on [Keep a Changelog](https://keepachangelog.co
 
 ## [Unreleased]
 
+## [2.19.0]
+
+- Update fiberplane dependencies
 - Add `integrations list` command (#267)
 
 ## [2.17.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format of this file is based on [Keep a Changelog](https://keepachangelog.co
 - Update fiberplane dependencies
 - Add `integrations list` command (#267)
 
+## [2.18.0]
+
+- Update fiberplane dependencies
+
 ## [2.17.0]
 
 - Fixed an issue with CLI argument completion failing. (#264)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fp"
-version = "2.20.0"
+version = "2.19.0"
 authors = ["Team Fiberplane"]
 edition = "2018"
 build = "build.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fp"
-version = "2.18.0"
+version = "2.20.0"
 authors = ["Team Fiberplane"]
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
This PR bumps the version numbers so they match the next release.
Please verify the version numbers are correct, and update the CHANGELOG manually. You
should merge this PR ASAP, but no later than before the next release cycle starts.

# Checklist

- [x] Version numbers are correct
- [x] `CHANGELOG.md` has been updated