### PR TITLE
Bump minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format of this file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [2.22.0] - TBD
+## unreleased
+
+## [2.23.0] - 2024-03-01
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "fp"
-version = "2.21.0"
+version = "2.23.0"
 dependencies = [
  "abort-on-drop",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fp"
-version = "2.22.0"
+version = "2.23.0"
 authors = ["Team Fiberplane"]
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
This PR bumps the version numbers so they match the next release.
Please verify the version numbers are correct, and update the CHANGELOG manually. You
should merge this PR ASAP, but no later than before the next release cycle starts.

# Checklist

- [x] Version numbers are correct
- [x] `CHANGELOG.md` has been updated